### PR TITLE
downgrade a package dependency 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "cra-template": "1.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.0.2",
+    "react-router-dom": "^6.29.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^4.2.4"
   },


### PR DESCRIPTION
we don't support react router dom 7.0 yet , when we do , we can rev this. otherwise it breaks.