### PR TITLE
replace deprecated openjdk base image

### DIFF
--- a/.devcontainer/Java/devcontainer.json
+++ b/.devcontainer/Java/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "gradle_jdk23",
+	"image": "gradle:jdk23",
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "false",
+			"installGradle": "false"
+		}
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "default codespace",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {}
+}

--- a/.env_EXAMPLE
+++ b/.env_EXAMPLE
@@ -1,0 +1,2 @@
+REACT_APP_AIRLINES_API_URL=https://YOUR_CODESPACE_AIRLINES_URL.app.github.dev/airlines
+REACT_APP_FLIGHTS_API_URL=https://YOUR_CODESPACE_FLIGHTS_URL.app.github.dev/flights

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 .gradle
+__pycache__

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,12 @@ up:
 down:
 	docker compose down
 
+
+backends:
+	docker compose --profile backends up --build
+
+ui:
+	docker compose --profile ui up --build
+
+
 .PHONY: up down

--- a/airlines/Dockerfile
+++ b/airlines/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN gradle clean bootJar
 
 # Step 2: Use a lightweight JDK image for running the app
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-alpine
 
 # Set the working directory for the runtime container
 WORKDIR /app

--- a/airlines/src/main/java/com/example/springboot/AirlinesController.java
+++ b/airlines/src/main/java/com/example/springboot/AirlinesController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
 @RestController
-@CrossOrigin(origins = "http://localhost:3000") // Allow requests from React app
+@CrossOrigin(origins = "*") // Allow requests from React app
 public class AirlinesController {
 	private static String[] airlines = { "AA", "DL", "UA" };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,19 @@ services:
       context: ./airlines
     ports:
       - "8080:8080"
+    profiles: [backends]
   flights:
     build: 
       context: ./flights
     ports:
       - "5001:5001"
+    profiles: [backends]
   frontend:
     build: 
       context: ./frontend
     ports:
       - "3000:3000"
+    profiles: [ui]
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,6 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
+    environment: 
+      REACT_APP_AIRLINES_API_URL: ${REACT_APP_AIRLINES_API_URL}
+      REACT_APP_FLIGHTS_API_URL: ${REACT_APP_FLIGHTS_API_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '1'
 services:
   airlines:
     build: 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,5 +16,8 @@ COPY . .
 # Expose the port on which the app will run
 EXPOSE 3000
 
+ENV REACT_APP_AIRLINES_API_URL ${REACT_APP_AIRLINES_API_URL}
+ENV REACT_APP_FLIGHTS_API_URL ${REACT_APP_FLIGHTS_API_URL}
+
 # Start the React development server
 CMD ["npm", "start"]

--- a/frontend/src/pages/Airlines.js
+++ b/frontend/src/pages/Airlines.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import axios from "axios";
 import "./Airlines.css";
 
-const AIRLINES_API_URL = "http://localhost:8080/airlines";
+const AIRLINES_API_URL = process.env.REACT_APP_AIRLINES_API_URL;
 
 function Airlines() {
   const [data, setData] = useState(null);

--- a/frontend/src/pages/Flights.js
+++ b/frontend/src/pages/Flights.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import axios from "axios";
 import "./Flights.css";
 
-const FLIGHTS_API_URL = "http://localhost:5001/flights";
+const FLIGHTS_API_URL = process.env.REACT_APP_FLIGHTS_API_URL;
 const AIRLINES = ["AA", "DL", "UA"];
 
 function Flights() {


### PR DESCRIPTION
In recent test runs of this project I have encountered Docker Compose failing to build the Airlines image.

The openjdk image being used in the airlines project is deprecated:
[https://hub.docker.com/_/openjdk](https://hub.docker.com/_/openjdk)

I have found and tested [this replacement](https://hub.docker.com/layers/library/eclipse-temurin/17-jdk-alpine/images/sha256-24643c2dd329ef482ecd042b59cbfb7fe13716342e22674a0abd763559c8a1dd?context=explore).

It is not great in terms of vulnerabilities but so far it gets me past the build problem, and the project runs correctly so far.