### PR TITLE
Switching to non-deprecated jdk

### DIFF
--- a/airlines/Dockerfile
+++ b/airlines/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN gradle clean bootJar
 
 # Step 2: Use a lightweight JDK image for running the app
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17
 
 # Set the working directory for the runtime container
 WORKDIR /app


### PR DESCRIPTION
Switches from the deprecated openjdk image to the supported eclipse-temurin:17 jdk image.